### PR TITLE
Add codex delegation skills (invoke / task-waves / issue-waves)

### DIFF
--- a/CODEX_WAVES.md
+++ b/CODEX_WAVES.md
@@ -1,0 +1,102 @@
+# Codex delegation flow
+
+Single chart showing how `invoking-codex-exec`, `codex-task-waves`, and `codex-issue-waves` relate. Pick the entry by task shape; the lower skills layer on the primitive.
+
+```mermaid
+flowchart TD
+    Start([User asks to delegate to codex]) --> Shape{Task shape?}
+
+    Shape -->|"1 issue, no plan needed<br/>(one-shot dispatch)"| Exec
+    Shape -->|"1 task, needs plan<br/>+ review checkpoints"| Task
+    Shape -->|"≥2 issues<br/>parallel batch"| Issue
+
+    %% ── invoking-codex-exec (primitive) ──
+    subgraph Exec["invoking-codex-exec — primitive"]
+        direction TB
+        E1[Set required flags:<br/>--dangerously-bypass-approvals-and-sandbox<br/>-C worktree --skip-git-repo-check] --> E2[Launch codex in background<br/>capture PID + log file]
+        E2 --> E3[Wait by PID, not log regex]
+        E3 --> E4{Sandbox spiral<br/>detected?}
+        E4 -->|yes| E5[KILL → relaunch with bypass flag]
+        E5 --> E2
+        E4 -->|no| E6[git status + git diff<br/>trust-but-verify]
+        E6 --> E7([Done / handoff])
+    end
+
+    %% ── codex-task-waves ──
+    subgraph Task["codex-task-waves — single task, planned"]
+        direction TB
+        T1[Identify 'this'] --> T2[Write PLAN_TICKET.md<br/>in worktree]
+        T2 --> T3{Wave count?<br/>1 / 2 / 3 / 4+}
+        T3 --> T4[State count + rationale<br/>to user]
+        T4 --> T5[Wave loop start]
+        T5 --> T6[Dispatch wave via<br/>invoking-codex-exec]
+        T6 --> T7[Verify diff +<br/>run wave verification]
+        T7 --> T8[Review:<br/>claude subagent default<br/>fresh claude -p escalation<br/>NEVER codex]
+        T8 --> T9{Findings?}
+        T9 -->|blocking small| T10[Fix in place]
+        T9 -->|blocking large| T11[Respawn codex<br/>focused correction prompt]
+        T9 -->|none / nits| T12[Commit wave<br/>conventional prefix]
+        T10 --> T12
+        T11 --> T7
+        T12 --> T13[Full project verification]
+        T13 --> T14{More waves?}
+        T14 -->|yes| T5
+        T14 -->|no| T15[Strip plan file<br/>push + open PR<br/>wave-by-wave summary]
+    end
+
+    %% ── codex-issue-waves ──
+    subgraph Issue["codex-issue-waves — multi-issue parallel"]
+        direction TB
+        I1[Pre-dispatch:<br/>conflict triage between issues] --> I2{Conflicts?}
+        I2 -->|yes| I3[Combine / sequence /<br/>skip umbrella issues]
+        I2 -->|no| I4[Per-issue worktree<br/>.worktrees/issue-N-slug]
+        I3 --> I4
+        I4 --> I5[Fetch issue body<br/>write focused prompt]
+        I5 --> I6[Launch all codex runs<br/>in parallel via invoking-codex-exec]
+        I6 --> I7[Schedule single<br/>aggregated wakeup]
+        I7 --> I8[Monitor: PR URL +<br/>gh pr view CI status]
+        I8 --> I9[Review wave:<br/>parallel claude subagents<br/>one per PR]
+        I9 --> I10[Spot-checks:<br/>git log/diff/grep<br/>conflict markers/TODO/AI refs]
+        I10 --> I11{Blockers?}
+        I11 -->|small| I12[Fix in worktree<br/>force-with-lease push]
+        I11 -->|large| I13[Respawn codex<br/>correction prompt]
+        I12 --> I14[Wait for CI via<br/>scripts/wait_for_ci.sh]
+        I13 --> I14
+        I11 -->|none| I14
+        I14 --> I15[Decide merge order<br/>conflict-aware]
+        I15 --> I16[scripts/merge_and_cleanup.sh<br/>squash → rm worktree → del branch]
+    end
+
+    %% Layering: task-waves and issue-waves call back into invoking-codex-exec
+    T6 -.uses.-> Exec
+    T11 -.uses.-> Exec
+    I6 -.uses.-> Exec
+    I13 -.uses.-> Exec
+
+    E7 --> Done([Task delegated])
+    T15 --> Done
+    I16 --> Done
+
+    classDef primitive fill:#1f3a5f,stroke:#4a90e2,color:#fff
+    classDef single fill:#2d5016,stroke:#7cb342,color:#fff
+    classDef multi fill:#5d2f8f,stroke:#ab47bc,color:#fff
+    class Exec primitive
+    class Task single
+    class Issue multi
+```
+
+## Reading the chart
+
+- **Entry decision** is `Task shape?` — pick exactly one path.
+- **Dotted arrows** = layering. `codex-task-waves` and `codex-issue-waves` both *call* `invoking-codex-exec` for the actual codex launch; they don't reimplement flag handling or PID waits.
+- **Reviewer is never codex.** All three paths use claude (in-harness subagent default, fresh `claude -p` for high-stakes). Codex = autonomous execution. Review = read+reason.
+- **Worktree isolation** is universal. All three skills run codex pinned to a worktree via `-C <worktree>`.
+- **Trust-but-verify** is universal. Always `git status` + `git diff` before declaring success or killing a stuck run.
+
+## Skill picker — quick
+
+| Trigger | Skill |
+|---------|-------|
+| "Run codex on this" / one-shot | `invoking-codex-exec` |
+| "Have codex fix this ticket" / planned single task | `codex-task-waves` |
+| "Spawn codex on issues #A #B #C" / parallel batch | `codex-issue-waves` |

--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@ A curated collection of agent skills for developer tools, infrastructure, media 
 | [langfuse-observability](langfuse-observability/) | LLM observability with Langfuse (traces, costs, metrics) | `npx skills add ddnetters/agent-skills@langfuse-observability` |
 | [plex-media-server](plex-media-server/) | Plex Media Server API and management | `npx skills add ddnetters/agent-skills@plex-media-server` |
 | [slite-knowledge-base](slite-knowledge-base/) | Slite knowledge base API — ask, search, notes, and knowledge health | `npx skills add ddnetters/agent-skills@slite-knowledge-base` |
+| [invoking-codex-exec](invoking-codex-exec/) | One-shot `codex exec` dispatch — flags, sandbox traps, PID-based monitoring, recovery | `npx skills add ddnetters/agent-skills@invoking-codex-exec` |
+| [codex-task-waves](codex-task-waves/) | Single-task codex delegation — plan → split into waves → dispatch → review → PR | `npx skills add ddnetters/agent-skills@codex-task-waves` |
+| [codex-issue-waves](codex-issue-waves/) | Multi-issue parallel codex batches in isolated worktrees, then review and merge waves | `npx skills add ddnetters/agent-skills@codex-issue-waves` |
+
+See [CODEX_WAVES.md](CODEX_WAVES.md) for the end-to-end flowchart across the three codex skills.
 
 ## Install all
 

--- a/codex-issue-waves/SKILL.md
+++ b/codex-issue-waves/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: codex-issue-waves
+description: Run a batch of GitHub issues through codex exec in isolated git worktrees as parallel autonomous PRs, then manage the review and correction waves until merge. Use when the user gives a list of issue numbers (≥ 2) and asks to "spawn codex" / "dispatch codex" / "have codex work on" / "manage the PRs" / "process feedback" / "get them merged" for those issues, or when the user asks for multi-issue parallel delegation to codex. Not for single-issue wave-driven delegation (use codex-task-waves), single-issue one-shot dispatch (use invoking-codex-exec), or implementation without delegation (use /pr or direct implementation).
+---
+
+# Codex Issue Waves
+
+Run GitHub issues through `codex exec` in isolated worktrees, then shepherd the resulting PRs through review and merge. Four phases: dispatch → monitor → review wave → correction wave.
+
+**Orchestration model.** Claude code is the orchestrator. Codex is the implementer (one process per worktree, parallel). Reviewers are claude — either in-harness subagents (default, parallel one-per-PR via `superpowers:dispatching-parallel-agents`) or fresh `claude -p` (escalation for high-stakes PRs). Codex is never used for review.
+
+## When to use
+
+Triggered by requests like:
+- "Spawn codex on issues #A, #B, #C"
+- "Have codex handle these issues in parallel"
+- "Manage the PRs" / "process feedback" after such a batch
+- "Get them merged"
+
+Not for: single-issue work (implement directly or use `/pr`), or batches where codex CLI isn't available on the host.
+
+## Pre-dispatch: conflict triage
+
+Before creating any worktree, surface conflicts between issues in the batch. Don't just fan out blindly.
+
+Run through this checklist for every pair of issues:
+- **Same file, same region?** Two issues mutating the same function / component / migration will guarantee a merge conflict. Combine into one branch or sequence them.
+- **Semantic overlap?** One issue removes the surface another targets. Example: one PR replaces `edit_suggestions[]` with `claim_verdicts[]`; another adds a feature on top of `edit_suggestions[]`. Flag before dispatch.
+- **Shared numbering?** Any two ADRs, migrations, or ordered resource types that would collide on merge (e.g., both land `005-*.md`). Decide the ordering upfront; the later one bumps on merge.
+- **Umbrella / tracking issues?** Don't dispatch codex on a tracking issue that itemizes sub-issues. Pick the first unblocked sub-issue instead, or skip entirely.
+- **Trivial siblings?** Two near-trivial fixes in the same file are cheaper as one combined branch than two parallel codex runs that will fight at merge.
+
+Always pause here and surface findings to the user with a concrete proposal ("combine these two, skip the umbrella, run the rest in parallel"). Do not proceed silently. Only after user confirms, continue.
+
+## Dispatch phase
+
+**REQUIRED SUB-SKILL:** Use `invoking-codex-exec` for the codex launch mechanics — flags, sandbox traps, monitoring, kill-and-recover. This skill does not duplicate that content; it covers only the multi-issue orchestration on top.
+
+For each (possibly combined) issue to dispatch:
+
+1. Fetch origin/main and create a worktree off it. Naming: `.worktrees/issue-<number>-<slug>` and branch `feat/<slug>` / `refactor/<slug>` / `fix/<slug>` depending on the issue type.
+2. Fetch the issue body from GitHub.
+3. Write a focused prompt per worktree. See `references/prompt-template.md` for the shape — the prompt is the single most important artifact in this workflow.
+4. Launch codex in background per `invoking-codex-exec`, redirecting output to `/tmp/codex-runs/<n>.out`.
+
+See `references/common-commands.md` for the exact shell recipes (worktree creation, issue fetch, codex launch).
+
+Schedule a wakeup to check back (~10–15 min for moderate refactors, ~5 min for trivial changes, ~20 min for big architectural work). Do not sleep-poll in bash. If multiple runs are outstanding, schedule a single aggregated wakeup, not one per run.
+
+## Monitor phase
+
+When a codex run finishes, immediately check:
+- Does the output end with a `pull/<N>` URL? If not, codex aborted partway — tail the output to find out why.
+- CI status on the PR via `gh pr view <N> --json statusCheckRollup,mergeable,mergeStateStatus`.
+- Any obvious red flags in the tail of the output (conflict markers, test failures, "I couldn't do X" messages). Codex's live logging sometimes shows `<<<<<<< / =======` markers while it resolves conflicts. These are transient. **Always verify against `gh pr diff <N>`** before reporting "conflict markers in committed code."
+
+If multiple codex runs are still outstanding, reschedule a single aggregated wakeup; do not schedule one per run.
+
+## Review wave
+
+Treat every codex-produced PR as untrusted. Trust-but-verify.
+
+For each PR:
+
+1. **State check** — CI green, mergeable, not just "running". A green `test` check is necessary but not sufficient: `tsc --noEmit` is sometimes not part of CI even when tests pass. If the repo type-checks separately, run it manually.
+
+2. **Manual spot-checks** — always:
+   - `git log --oneline origin/main..origin/<branch>` to confirm a sane rebase shape (no ghost/lost commits)
+   - `git diff origin/main...origin/<branch> --stat` to sanity-check blast radius
+   - `grep` the diff for any stragglers from renames codex was asked to perform (old names / routes / file paths)
+   - Skim the diff for conflict markers, `TODO`, `FIXME`, `console.log`, AI-tool references (Claude / Codex / Copilot), and any `--no-verify` in commit messages
+
+3. **Independent code review** — claude code is the orchestrator; reviewers are claude. Two delegation targets, never codex:
+
+   - **Default (parallel)** — dispatch one in-harness `superpowers:code-reviewer` subagent per PR/worktree, fired together via `superpowers:dispatching-parallel-agents`. Each subagent reads its own worktree's diff (`git diff origin/main...origin/<branch>`), the issue spec, the spot-check notes, and CLAUDE.md / AGENTS.md. Results return as structured findings ready to merge into the orchestrator's working state.
+   - **Escalation (per PR, sequential)** — fresh `claude -p --dangerously-skip-permissions --add-dir <worktree> --output-format json --model opus "<review prompt>"` for high-stakes PRs (production-critical, security-sensitive, or where the issue spec itself may be wrong). Clean-room context, no main-session bias. See `codex-task-waves`'s "Review delegation" section for the full invocation template.
+   - **Never codex** — codex's value is autonomous execution; review is read+reason. Same sandbox traps as `invoking-codex-exec` apply for zero benefit.
+
+   Whichever target is used, the reviewer should look at:
+   - Rebase integrity (nothing lost from concurrent merges to main)
+   - Correctness of renames / retargets
+   - Race conditions in new DB writes (the select-then-insert antipattern is common — prefer `INSERT ... ON CONFLICT DO UPDATE` for upserts)
+   - Redundant migration blocks (codex tends to duplicate bootstrap + migration for the same table)
+   - UI parity across sibling pages (if the feature lives in both a list and a detail view, check both)
+   - Test gaps (UNIQUE constraints, auth paths, toggle-off-then-on flows)
+   - Project-rule compliance (no AI references, conventional commits, no skipped hooks)
+
+4. **Categorize findings**:
+   - **Blocking**: TS errors, missing parity with ADR/issue spec, real data-integrity bugs, security. These must be fixed before merge.
+   - **Should-fix**: performance, race conditions, test gaps, small regressions. Fix now unless explicitly scoped out.
+   - **Nit/follow-up**: style, future extractions, documentation. Post as comment; don't block.
+
+5. **Cross-check reviewer against the issue spec.** Code-reviewer agents sometimes flag a feature as "scope change" when it was in fact asked for in the issue. Read the issue body yourself before insisting on a "scope change" fix.
+
+## Correction wave
+
+Two paths for blockers:
+
+**Path A — fix in-place**: If the blockers are small (< ~5 files, < ~100 lines) and you understand them, just fix them yourself in the worktree. Faster than respawning codex. Run tests, commit, `git push --force-with-lease` (rebased branches only — use `--force-with-lease` not `--force`).
+
+**Path B — respawn codex**: If the corrections are large (rebase conflicts, renames across 10+ files, new subsystem) OR require exploring the codebase to understand, write a focused correction prompt and respawn codex on the same worktree. See `references/prompt-template.md` for the correction-prompt shape.
+
+After either path:
+- Post a PR comment summarizing what changed (so the reviewer agent doesn't have to re-read the whole diff).
+- Wait for CI via `scripts/wait_for_ci.sh <PR>` — run it through the harness's background-command mechanism so the exit event wakes the agent; do not inline-poll in bash.
+- If still blocked, another review round; otherwise merge.
+
+## Merge + cleanup
+
+When CI is green, the reviewer is satisfied, and the blocking items are done:
+
+1. Decide merge order if multiple PRs are ready. Order matters when:
+   - They both touch conflicting files (merge simpler first so the other rebases cleanly).
+   - One supersedes another semantically (merge the reframe first; rework its dependent branch after).
+   - ADR numbers collide (whichever lands first claims the number; the other renumbers in the correction wave — do not ask codex to "merge in a specific order", do it manually).
+2. Run `scripts/merge_and_cleanup.sh <PR> <worktree-path> <branch>` — squash-merges, then removes the worktree, then deletes the local branch, in the only order that works. Doing this by hand is error-prone because `git branch -D` fails while a worktree pins the branch, so always go through the script (or follow the exact sequence in `references/common-commands.md`).
+
+## Deploy (only if asked)
+
+Merging to main does not auto-deploy in most repos. If the user asks to "deploy" after a merge, check the repo's workflows to see what triggers deploy — commonly a `workflow_dispatch` on a Deploy workflow. Production is shared infrastructure; confirm environment (development / staging / production) before dispatching.
+
+## Key pitfalls
+
+See `references/pitfalls.md` for the full list. The top three are:
+
+- **Codex builds, claude reviews** — claude code is the orchestrator; codex is for implementation only. Reviewers are always claude (in-harness subagent or fresh `claude -p`). Never dispatch codex for the review wave.
+- **Self-review is blocked by GitHub** — `gh pr review --approve` fails with "cannot approve your own PR". Post via `gh pr comment` instead.
+- **Worktree pins branch** — local branch delete fails until the worktree is removed. Always clean in that order.
+- **Codex output ≠ committed code** — transient conflict markers in the codex log are not the same as committed markers. Verify with `gh pr diff` before raising the alarm.
+
+## Success criteria
+
+The batch is done when:
+- Every non-skipped issue has an open or merged PR.
+- Every open PR has been through both the spot-check and the reviewer-agent pass.
+- No PR has been merged without at least one human-visible summary comment explaining what was changed vs the review feedback.
+- Every worktree created by this skill has been removed after its branch merged.

--- a/codex-issue-waves/references/common-commands.md
+++ b/codex-issue-waves/references/common-commands.md
@@ -1,0 +1,177 @@
+# Common Commands
+
+Exact shell recipes for each phase. Copy-adapt, don't rewrite from memory.
+
+## Worktree + issue body setup
+
+```bash
+# From the repo root
+git fetch origin
+mkdir -p .worktrees /tmp/codex-runs
+
+# Per issue
+git worktree add -b <branch-name> .worktrees/issue-<N>-<slug> origin/main
+gh issue view <N> --json title,body > /tmp/codex-runs/issue-<N>.json
+```
+
+Branch naming by type: `feat/<slug>` for new features, `fix/<slug>` for bug fixes, `refactor/<slug>` for refactors, `chore/<slug>` for chores.
+
+## Launching codex
+
+Always background it, always redirect output:
+
+```bash
+codex exec \
+  --dangerously-bypass-approvals-and-sandbox \
+  --cd /absolute/path/to/.worktrees/issue-<N>-<slug> \
+  --skip-git-repo-check \
+  "$(cat /tmp/codex-runs/prompt-<N>.md)" \
+  > /tmp/codex-runs/<N>.out 2>&1
+```
+
+Put this inside your harness's `run_in_background: true`-equivalent call so the agent isn't blocked.
+
+Flags explained:
+- `--dangerously-bypass-approvals-and-sandbox` — codex runs fully autonomously. Required for this skill.
+- `--cd <worktree>` — codex treats the worktree as its root. Without this it picks up the main worktree's HEAD.
+- `--skip-git-repo-check` — silences a warning; harmless either way.
+
+## Monitoring without polling
+
+Do not use `while sleep` in bash — sleep loops are often blocked by the harness. Two options:
+
+**Option A — schedule a wakeup.** Set a delay (~10–15 min for moderate refactors) and come back to tail the output file.
+
+**Option B — until-loop with a single condition.** When you truly need to block until a specific event, use the bundled script:
+
+```bash
+# Blocks until the `test` check (or a named check) reports final SUCCESS/FAILURE.
+# Run via the harness's background-command mechanism so the exit notification wakes the agent.
+bash "$SKILL_DIR/scripts/wait_for_ci.sh" <PR>               # waits on check "test"
+bash "$SKILL_DIR/scripts/wait_for_ci.sh" <PR> build-deploy  # waits on a different check
+WAIT_FOR_CI_INTERVAL=30 bash "$SKILL_DIR/scripts/wait_for_ci.sh" <PR>  # override poll interval
+```
+
+Exit codes: `0` = SUCCESS/NEUTRAL/SKIPPED, `1` = FAILURE/CANCELLED/TIMED_OUT, `2` = bad input.
+
+Raw equivalent if you don't want to call the script:
+
+```bash
+until [ "$(gh pr view <N> --json statusCheckRollup --jq '.statusCheckRollup[] | select(.name=="test") | .status')" = "COMPLETED" ]; do
+  sleep 20
+done
+```
+
+Run this via the harness's background-command mechanism, not inline. The harness will notify when it exits.
+
+Never poll for a codex run's completion with `ps aux | grep` — rely on the run-in-background exit notification.
+
+## Reviewing a finished codex run
+
+```bash
+# Did it open a PR?
+tail -30 /tmp/codex-runs/<N>.out
+
+# PR state
+gh pr view <N> --json state,mergeable,mergeStateStatus,statusCheckRollup | \
+  jq '{state, mergeable, mergeStateStatus, checks: [.statusCheckRollup[] | {name, conclusion}]}'
+
+# Commits on branch
+git log --oneline origin/main..origin/<branch>
+
+# Full diff (big, pipe to grep)
+gh pr diff <N>
+
+# File-shape audit
+git diff origin/main...origin/<branch> --stat
+
+# Straggler hunt for a rename (example)
+git diff origin/main...origin/<branch> | grep -nE "old_name|OldName|/old/"
+
+# Conflict marker hunt in committed code (not codex log)
+gh pr diff <N> | grep -nE "^(<<<<<<<|=======|>>>>>>>)"
+```
+
+## Fix-in-place workflow
+
+```bash
+cd /absolute/path/to/.worktrees/issue-<N>-<slug>
+
+# Sync with what's on origin (codex may have force-pushed)
+git fetch origin
+git reset --hard origin/<branch>
+
+# Rebase on main if needed
+git rebase origin/main
+
+# Make edits ... then:
+npm test --workspaces --if-present
+npx tsc --noEmit -p packages/web/tsconfig.json   # if repo type-checks separately
+
+git add <specific files>
+git commit -m "fix: <summary>"
+git push --force-with-lease
+```
+
+Always `--force-with-lease`, never `--force` — protects against racing with codex if it pushed something meanwhile.
+
+## PR comments and reviews
+
+```bash
+# Leave a summary comment (can approve your own work via comment, but not via review)
+gh pr comment <N> --body "$(cat <<'EOF'
+Addressed the review findings in <sha>:
+- <blocker 1>: <fix summary>
+- <blocker 2>: <fix summary>
+- <nit>: <fix summary>
+
+Tests: <core>/<api>/<web> green.
+EOF
+)"
+```
+
+GitHub blocks you from approving your own PR (`addPullRequestReview` → "Review Can not approve your own pull request"). Post as a regular comment instead; merge button doesn't require approval unless the branch protection enforces it.
+
+## Merge + cleanup (in this exact order)
+
+Prefer the bundled script — it encodes the order:
+
+```bash
+bash "$SKILL_DIR/scripts/merge_and_cleanup.sh" <PR> <worktree-path> <branch>
+# e.g.
+bash "$SKILL_DIR/scripts/merge_and_cleanup.sh" 143 .worktrees/issue-131-suggestion-feedback feat/suggestion-feedback
+# MERGE_STRATEGY=rebase bash "$SKILL_DIR/scripts/merge_and_cleanup.sh" <PR> <path> <branch>  # to override squash
+```
+
+Raw equivalent (in this exact order — swap and it breaks):
+
+```bash
+# 1. Merge (may print "failed to delete local branch" — expected, see below)
+gh pr merge <N> --squash --delete-branch
+
+# 2. Confirm it actually merged
+gh pr view <N> --json state,mergedAt
+
+# 3. Remove the worktree — until this runs, the local branch is pinned
+git worktree remove .worktrees/issue-<N>-<slug>
+
+# 4. Delete the local branch if gh didn't manage to
+git branch -D <branch>
+```
+
+If step 1 reports `failed to delete local branch ... used by worktree`, that's expected — `gh` has already merged + deleted on the remote; just run steps 3 and 4.
+
+## Deploy (only when asked)
+
+```bash
+# See what workflows exist
+ls .github/workflows/
+
+# Look at the triggers in the deploy workflow
+grep -A5 "^on:" .github/workflows/deploy.yml
+
+# Dispatch (replace env as needed)
+gh workflow run "Deploy" --ref main -f environment=development
+```
+
+Never deploy to production without explicit user confirmation for the target environment.

--- a/codex-issue-waves/references/pitfalls.md
+++ b/codex-issue-waves/references/pitfalls.md
@@ -1,0 +1,89 @@
+# Pitfalls
+
+Specific failure modes encountered running this workflow. Read before your first dispatch of a session; you'll save real time.
+
+## Dispatch-time mistakes
+
+### Blindly parallelizing issues that touch the same file
+Two "tiny" issues editing adjacent lines of the same component will conflict at merge. Combine them on one branch.
+
+### Running codex on an umbrella tracking issue
+Codex will try to do all sub-issues at once. Result: one giant PR with everything half-done. Dispatch on the first unblocked sub-issue instead.
+
+### Not inlining the issue spec in the prompt
+Codex may skip `gh issue view`, re-read it mid-flight and lose context, or guess. Paste the body verbatim.
+
+### Forgetting to fence scope
+Codex is eager to clean up adjacent code. Without explicit "do NOT touch X", it will refactor things outside the issue's scope and your PR doubles in size.
+
+## Monitoring mistakes
+
+### Reading codex's live output as if it were the committed diff
+When codex is mid-conflict-resolution, its stdout logging can contain `<<<<<<<`, `=======`, `>>>>>>>` markers. These are transient. Always verify against `gh pr diff <N>` — what got committed is often clean.
+
+### Polling codex with `ps aux | grep`
+Unreliable across shells and environments. The only trustworthy signal is the harness's background-command completion event.
+
+### Scheduling a wakeup per run
+If three runs are outstanding, one aggregated wakeup that checks all three is cheaper than three wakeups.
+
+## Review-time mistakes
+
+### Treating a green CI as "ready to merge"
+Vitest doesn't always type-check what it imports — a prop-name typo can pass tests and still break `tsc --noEmit`. Run the type-checker manually before merge if the repo separates them.
+
+### Assuming the reviewer agent is correct about scope
+Reviewer agents sometimes flag a deliberate-per-issue-spec behavior as "out of scope". Re-read the issue before asking for it to be stripped.
+
+### Self-approving via `gh pr review --approve`
+GitHub API blocks self-review. Use `gh pr comment` instead. The PR can still be merged (unless branch protection requires a reviewer from someone else, in which case you need another human).
+
+### Missing UI parity checks
+If a feature renders in both a list and detail view (Review + ResultDetail is the canonical example), codex often only adds it to one. Check both before merge.
+
+### Accepting select-then-insert upsert code
+Race condition by default. Push back and request `INSERT ... ON CONFLICT DO UPDATE` or a transaction.
+
+### Missing tests for
+- UNIQUE constraints (direct insert-insert test that asserts the constraint fires)
+- Unauthenticated/forbidden paths if the route handler still has inline 401/403 checks
+- Toggle-off-then-on paths (ID reuse, row recreation)
+
+### Forgetting to audit straggler renames
+Codex renames `X` to `Y` but leaves `X` in a test file, a comment, or an unused import. Always grep the diff for the old name.
+
+## Correction-wave mistakes
+
+### Rebasing without resetting
+If codex force-pushed while you were mid-review, `git reset --hard origin/<branch>` the worktree before you start editing or your fixes apply to a stale tree.
+
+### Using `--force` instead of `--force-with-lease`
+`--force` will stomp codex's concurrent push. `--force-with-lease` will refuse and tell you.
+
+### Pushing without bumping the PR description
+If the PR body still describes the pre-fix behavior, reviewers get confused. Update via `gh pr edit <N>` or at least post a clear comment.
+
+### Asking codex to re-do a 3-line fix
+Respawning codex for small corrections wastes 5–10 minutes and hundreds of thousands of tokens. If you can make the fix in two edits, just do it.
+
+## Merge-time mistakes
+
+### Merging without considering order
+When two PRs both touch the same file or share an ADR number, merge the one with fewer downstream effects first. The second one rebases cleanly then.
+
+### Running `git branch -D` before `git worktree remove`
+Silently fails — the branch is pinned. Remove the worktree first.
+
+### Merging an obsolete feature
+If a superseding PR merged while a dependent PR was open, the dependent may now target a deleted surface. Don't merge just because CI is green; verify the surface still exists.
+
+## Deploy-time mistakes
+
+### Assuming merge triggers deploy
+Usually doesn't. Most repos require a `workflow_dispatch` to deploy. Check `.github/workflows/` before claiming "deployed".
+
+### Dispatching to production without confirmation
+Deploy is shared infrastructure. Even if user says "deploy", ask which environment unless they said "production" explicitly.
+
+### Choosing an environment codex-style
+Never pick production for "Build and deploy (default)" — that's an undocumented choice. Make the environment selection explicit.

--- a/codex-issue-waves/references/prompt-template.md
+++ b/codex-issue-waves/references/prompt-template.md
@@ -1,0 +1,104 @@
+# Codex Exec Prompt Template
+
+The single most leveraged artifact in this workflow. The whole point of running codex autonomously is that it actually ships a PR without a babysitter — which only happens if the prompt is focused, self-contained, and explicit about non-negotiables.
+
+## Canonical shape (dispatch prompt)
+
+Every dispatch prompt should follow this skeleton. Inline everything codex needs; do not rely on it reading chat context.
+
+```
+You are an autonomous engineering agent working inside a git worktree on branch `<branch>`. The task is to fully implement GitHub issue **<org>/<repo>#<N>** and open a pull request.
+
+## Project rules (read first)
+
+Read these before writing any code:
+- <absolute/path/to/repo/CLAUDE.md>
+- <absolute/path/to/worktree/CLAUDE.md>
+
+[Inline the two or three rules that matter most for this task, verbatim:]
+- Never mention Claude, Codex, or any AI tool in code or commit messages.
+- Use conventional commit prefixes (`feat:`, `fix:`, `refactor:`, ...).
+- <e.g. "ADR required for structural DB changes in docs/adr/NNN-*.md">
+- <e.g. "inline migrations via PRAGMA table_info in db.ts">
+- Run `npm test` per workspace before committing. All must pass.
+
+## Issue #<N> specification
+
+[Paste the full issue body here. Do not truncate. Do not link to the issue — inline it. Codex should not need to run `gh issue view`.]
+
+## Execution steps
+
+Numbered, concrete, starting with `cd` into the worktree and reading CLAUDE.md. Include:
+1. cd + CLAUDE.md read
+2. Exploration of the specific files that will change (give absolute paths or `packages/.../file.ts` references so codex doesn't grep aimlessly)
+3. Concrete implementation steps in the order they should be done
+4. Tests — both new tests to write and existing suites to run
+5. Commit (conventional, no --no-verify)
+6. Push (`git push -u origin <branch>`, or `--force-with-lease` for rebased branches)
+7. Open PR via `gh pr create --title "..." --body "..."`. Spell out the title explicitly; for the body, say what must be in it (closes #<N>, summary, test plan).
+8. Return the PR URL
+
+## Non-negotiables
+
+- All tests must pass locally before commit.
+- No `--no-verify` on git commits.
+- No references to AI tools in code or messages.
+- If something is ambiguous, make a reasonable decision and note it in the PR description; do not block.
+- Return the PR URL when done.
+```
+
+## Rules that make prompts work
+
+- **Inline, don't link.** Codex reads what you give it. If you write `see issue #143 for details`, it will either do an extra tool call or just guess. Paste the issue body.
+- **Absolute paths for project-level rules.** `/Users/name/code/project/CLAUDE.md` is unambiguous; `CLAUDE.md` is ambiguous across worktrees.
+- **Concrete file pointers.** Instead of "update the repository", write "update `packages/core/src/repositories/sqlite/adapters/X.repository.ts`".
+- **Explicit scope fences.** "Do NOT touch Y — that is step #N's scope, not this PR." Codex is eager to clean up adjacent code; fence it.
+- **No hedging.** Write "switch to `INSERT ... ON CONFLICT DO UPDATE`". Don't write "consider using upsert semantics". Codex does exactly what you say.
+- **Return the PR URL.** State this as a non-negotiable so codex definitely surfaces it at the end.
+- **Don't babysit test commands.** Say "run `npm test` per workspace, all green." Don't list every command; codex knows `npm test`.
+
+## Correction prompt shape
+
+When respawning codex to address review feedback, the prompt looks similar but starts differently:
+
+```
+You are an autonomous engineering agent picking up an existing PR that needs to be reworked. The PR is <org>/<repo>#<N> on branch `<branch>`. Worktree is at `<absolute path>`. The branch may be behind `main` — rebase first.
+
+## What the PR does today
+
+[One paragraph summary so codex can orient without reading the whole diff.]
+
+## Why it needs rework
+
+[State the blocker from the review. Be specific — include the file and line where possible.]
+
+## What you need to do
+
+### 1. Rebase on origin/main
+`git fetch origin && git rebase origin/main`. Resolve conflicts cleanly in <list of expected files>.
+
+### 2. <concrete fix #1>
+<exact changes required, including file paths, old and new names, API shapes>
+
+### 3. <concrete fix #2>
+...
+
+### 4. Run tests + push + update PR
+
+- `npm test` per workspace.
+- `git push --force-with-lease` (because you rebased).
+- Update the PR description via `gh pr edit <N> --body-file -` or temp-file to reflect the rework.
+- Post a reply comment via `gh pr comment <N>` summarizing what you changed so the reviewer doesn't have to re-read the whole diff.
+
+## Non-negotiables
+
+[Same as dispatch prompt, plus any rework-specific rules.]
+```
+
+## Do not do
+
+- Don't tell codex to "be creative" or "make tradeoffs as you see fit" — it then invents scope. If a tradeoff has a right answer, say which one.
+- Don't let codex pick the commit message — give it the conventional-commits prefix and a one-line description.
+- Don't forget to say "rebase first" on correction prompts — codex happily stacks fix commits on a stale branch otherwise.
+- Don't include environment-specific hacks in the prompt (e.g. "if npm install fails, try yarn"). Let codex hit and report the real error.
+- Don't mix two issues into a single dispatch prompt unless you have explicitly combined them on one branch; otherwise codex does half of each.

--- a/codex-issue-waves/scripts/merge_and_cleanup.sh
+++ b/codex-issue-waves/scripts/merge_and_cleanup.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Squash-merge a PR and clean up its worktree + local branch in the correct order.
+#
+# The hard-won rule: `git branch -D` fails while a worktree pins the branch, and
+# `gh pr merge --delete-branch` only deletes the remote branch. This script
+# enforces the sequence:
+#   1. gh pr merge --squash --delete-branch  (merges + deletes remote branch)
+#   2. git worktree remove <path>            (unpins the local branch)
+#   3. git branch -D <branch>                (deletes the local branch)
+#
+# Usage:
+#   merge_and_cleanup.sh <PR_NUMBER> <WORKTREE_PATH> <BRANCH>
+#
+# Environment:
+#   MERGE_STRATEGY=squash|merge|rebase  (default: squash)
+
+set -euo pipefail
+
+if [[ $# -lt 3 ]]; then
+  echo "Usage: $0 <PR_NUMBER> <WORKTREE_PATH> <BRANCH>" >&2
+  exit 2
+fi
+
+pr="$1"
+worktree="$2"
+branch="$3"
+strategy="${MERGE_STRATEGY:-squash}"
+
+if ! [[ "$pr" =~ ^[0-9]+$ ]]; then
+  echo "PR_NUMBER must be an integer, got: $pr" >&2
+  exit 2
+fi
+
+case "$strategy" in
+  squash|merge|rebase) ;;
+  *) echo "MERGE_STRATEGY must be squash|merge|rebase, got: $strategy" >&2; exit 2 ;;
+esac
+
+# 1. Confirm PR is mergeable first (fail fast instead of mid-sequence).
+state="$(gh pr view "$pr" --json state,mergeable,mergeStateStatus \
+  --jq '{state, mergeable, mergeStateStatus} | "\(.state)|\(.mergeable)|\(.mergeStateStatus)"')"
+if [[ "${state%%|*}" != "OPEN" ]]; then
+  echo "PR #$pr is not OPEN (state: ${state%%|*}); aborting." >&2
+  exit 1
+fi
+
+# 2. Merge. `gh` may print "failed to delete local branch" — that is expected when
+#    a worktree is pinning the branch and is not fatal for us; we handle it next.
+echo "Merging PR #$pr (--$strategy)..."
+gh pr merge "$pr" "--$strategy" --delete-branch || {
+  echo "gh pr merge reported an error. Inspecting..." >&2
+  gh pr view "$pr" --json state,mergedAt --jq '.'
+  merged="$(gh pr view "$pr" --json state --jq '.state')"
+  if [[ "$merged" != "MERGED" ]]; then
+    echo "PR #$pr did not merge. Aborting cleanup." >&2
+    exit 1
+  fi
+  echo "PR #$pr is MERGED; the error was only about local-branch cleanup. Continuing." >&2
+}
+
+# 3. Remove the worktree (this releases the branch lock).
+if [[ -d "$worktree" ]]; then
+  echo "Removing worktree at $worktree..."
+  git worktree remove "$worktree"
+else
+  echo "Worktree $worktree not present; skipping." >&2
+fi
+
+# 4. Delete the local branch if it still exists.
+if git show-ref --quiet "refs/heads/$branch"; then
+  echo "Deleting local branch $branch..."
+  git branch -D "$branch"
+else
+  echo "Local branch $branch already gone; skipping." >&2
+fi
+
+echo "Done. PR #$pr merged, worktree + branch cleaned up."

--- a/codex-issue-waves/scripts/wait_for_ci.sh
+++ b/codex-issue-waves/scripts/wait_for_ci.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Block until a PR's `test` check (or a named check) reports a final conclusion.
+# Exits 0 on SUCCESS, 1 on failure/cancelled/timed_out, 2 on bad input.
+#
+# Usage:
+#   wait_for_ci.sh <PR_NUMBER> [CHECK_NAME]
+#
+# CHECK_NAME defaults to "test". Poll interval is 20s; override via WAIT_FOR_CI_INTERVAL.
+#
+# Run this in the harness's background-command mechanism, not inline — the harness
+# will notify when it exits so the agent isn't blocked.
+
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "Usage: $0 <PR_NUMBER> [CHECK_NAME]" >&2
+  exit 2
+fi
+
+pr="$1"
+check_name="${2:-test}"
+interval="${WAIT_FOR_CI_INTERVAL:-20}"
+
+if ! [[ "$pr" =~ ^[0-9]+$ ]]; then
+  echo "PR_NUMBER must be an integer, got: $pr" >&2
+  exit 2
+fi
+
+while true; do
+  raw="$(gh pr view "$pr" --json statusCheckRollup \
+    --jq ".statusCheckRollup[] | select(.name==\"$check_name\") | \"\(.status)|\(.conclusion)\"")" || {
+    echo "gh pr view failed for PR #$pr" >&2
+    exit 1
+  }
+
+  if [[ -z "$raw" ]]; then
+    echo "No check named '$check_name' found on PR #$pr (yet). Waiting ${interval}s..." >&2
+    sleep "$interval"
+    continue
+  fi
+
+  status="${raw%%|*}"
+  conclusion="${raw##*|}"
+
+  if [[ "$status" == "COMPLETED" ]]; then
+    echo "PR #$pr check '$check_name': $conclusion"
+    case "$conclusion" in
+      SUCCESS|NEUTRAL|SKIPPED) exit 0 ;;
+      *) exit 1 ;;
+    esac
+  fi
+
+  sleep "$interval"
+done

--- a/codex-task-waves/SKILL.md
+++ b/codex-task-waves/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: codex-task-waves
+description: Use when the user says "have codex fix this" / "have codex implement this" / "let codex handle this" / "give this to codex" / "delegate this to codex" for a single task with context already in scope (a Jira ticket, GitHub issue, file diff, bug, or described change). Plans the work, splits it into reviewable waves, dispatches codex per wave with review and correction between waves before opening a PR. Not for multi-issue parallel batches (use codex-issue-waves) or one-shot codex runs without planning (use invoking-codex-exec).
+---
+
+# Codex task waves
+
+Take a single in-scope task — "this" being the current Jira ticket, GitHub issue, bug, or described change — and produce one PR composed of one or more verified commits, each shaped by a written plan, a codex dispatch, and a review+correction round.
+
+**REQUIRED SUB-SKILLS:**
+- `invoking-codex-exec` — every wave's dispatch (flags, sandbox traps, monitoring)
+- `superpowers:writing-plans` — the plan file that drives every wave
+- `superpowers:requesting-code-review` — between every wave
+- `superpowers:using-git-worktrees` — worktree setup before wave 1
+
+## Phases
+
+1. **Identify "this"** — the task in scope. If ambiguous (multiple recent items, no recent context, fresh session), ask the user before proceeding. Don't guess.
+2. **Plan** — write a plan file in the worktree (`PLAN_<TICKET-ID>.md` or `PLAN.md`). Per `superpowers:writing-plans`: spec, root cause, proposed change, tests, verification commands, out-of-scope. The plan file is the artifact every wave reads.
+3. **Split into waves** — see "Wave splitting" below. Output: an ordered list of waves, each with a one-line goal and an "exit when..." condition.
+4. **Per-wave loop**: dispatch → verify → review → correct → commit → next.
+5. **Finalize** — strip the plan file, run full verification, push, open PR with a wave-by-wave summary.
+
+## Wave splitting
+
+The number of waves depends on the task's shape, not its size in lines:
+
+- **1 wave** — atomic changes. One-line fixes, single-function bugs, mechanical renames, isolated test additions, small refactors with a self-contained blast radius. Default to 1 wave unless a boundary earns its own review cycle.
+- **2 waves** — "set up the surface, then use it". E.g., add a domain field then wire it through; write a helper then call it; introduce a feature flag then ramp.
+- **3 waves** — changes that span a layered stack. Schema migration → repository/service → controller/UI. Or producer → wire format → consumer.
+- **4+ waves** — only when each wave verifies independently AND a later wave's design genuinely depends on the prior wave's actual landed code. Rare. Prefer 2–3.
+
+**Boundaries that work:**
+- Layer boundaries (domain / service / controller / UI)
+- Data-flow direction (producer → wire → consumer)
+- Feature flag stages (introduce gated → wire usage → flip → remove flag)
+- Tests-first as wave 1 if the user asked for strict TDD
+
+**Don't split when:**
+- The task is genuinely atomic (single rename, one-line bug, isolated type fix)
+- The user explicitly says "one-shot" / "don't split"
+- Each potential wave's diff is <~50 lines (review overhead exceeds the gain)
+
+**Don't merge waves when:**
+- A verification step (compile / test / lint) must pass before the next wave's design is final
+- The reviewer needs to see a clean diff per concern
+- A wave's correction round might invalidate a later wave's design
+
+State the wave count and rationale to the user before starting wave 1. Single-wave is a valid answer — say so explicitly so the user isn't surprised by a flat dispatch.
+
+## Per-wave loop
+
+For each wave, in order:
+
+1. **Dispatch** via `invoking-codex-exec`. The codex prompt must include:
+   - The plan file path and an instruction to read it first.
+   - The current wave's specific instructions and exit condition.
+   - The verification commands for this wave (compile, format, the relevant test slice).
+   - Boundary: "Do not touch surfaces from wave N+1" — name them.
+   - The same single-task boundaries: don't commit, don't push, don't edit CHANGELOG, don't bypass hooks.
+2. **Verify** — `git status` and `git diff` first (per `invoking-codex-exec` trust-but-verify). Run the wave's verification commands yourself if codex didn't, or if codex was killed mid-run.
+3. **Review** — see "Review delegation" below. Default is an in-harness claude subagent via `superpowers:requesting-code-review` / `superpowers:code-reviewer`. Brief it with the plan file, the wave's exit condition, and the wave's diff (`git diff <last-wave-commit>..HEAD`). **Never use codex for review** — it's a wrong-tool match for read+reason work, and the sandbox traps in `invoking-codex-exec` apply. Categorize findings:
+   - **Blocking** — must fix before next wave.
+   - **Should-fix** — fix in this wave unless explicitly out of scope.
+   - **Nit / follow-up** — annotate, defer to PR comment.
+4. **Correction round**:
+   - Small blockers (< ~5 files, < ~50 lines): fix in place yourself in the worktree. Faster than respawning codex.
+   - Large blockers (multi-file rework, design change, rebase conflicts): respawn codex on the same worktree with a focused correction prompt naming exactly what to fix and what not to touch.
+5. **Commit the wave** as a single commit. Conventional prefix matching the wave's nature (`fix:`, `feat:`, `refactor:`, `test:`). One commit per wave keeps the PR diff history reviewable.
+6. **Re-run the full project verification** (not just this wave's slice) before moving to the next wave. A wave that breaks an upstream test fails fast here, before downstream waves pile on.
+
+Move to the next wave only when the current wave is clean.
+
+## Review delegation
+
+Three review delegation targets exist. Pick by stakes, not by habit.
+
+| Target | When | Cost | Notes |
+|--------|------|------|-------|
+| **In-harness claude subagent** (default) | Most waves | ~10–30k tokens, ~10–30s | Use `superpowers:requesting-code-review` / `superpowers:code-reviewer` agent type. Inherits skills + project rules; structured findings wire straight back to the main session. Brief it with diff + plan + exit condition only — don't paste the full conversation. |
+| **Fresh `claude -p`** (escalation) | High-stakes waves: production-critical, security-sensitive, or when you suspect the *plan itself* may be wrong (clean-room second opinion) | ~30–80k tokens, ~30–60s | New process, no main-session bias, rediscovers skills/rules from disk. Symmetric mental model to dispatching codex but with no sandbox baggage. |
+| **`codex exec`** | **Never for review.** | — | Codex's value is autonomous execution; review is read+reason. Same sandbox traps as `invoking-codex-exec` apply for zero benefit. |
+
+### Fresh `claude -p` invocation
+
+```bash
+claude -p \
+  --dangerously-skip-permissions \
+  --add-dir <worktree> \
+  --output-format json \
+  --model opus \
+  "$(cat <<'PROMPT'
+You are reviewing wave <N> of the implementation plan at <worktree>/PLAN_<ID>.md.
+Read the plan first. Then review this diff against the plan and the project's
+CLAUDE.md / AGENTS.md rules:
+
+git diff <last-wave-commit>..HEAD
+
+Categorize findings as Blocking / Should-fix / Nit. Output JSON:
+{ "blocking": [...], "should_fix": [...], "nits": [...] }
+
+Don't suggest scope expansions. Don't run tests — assume they pass. Focus on
+correctness, race conditions, missed cases, project-rule compliance, and parity
+with the plan's exit condition.
+PROMPT
+)"
+```
+
+Use `--dangerously-skip-permissions` only inside an isolated worktree. The flag bypasses *all* permission checks for the spawned process — fine in a worktree under your control, dangerous elsewhere.
+
+Don't use `ultrareview` here — it's user-triggered and billed; you can't launch it autonomously.
+
+## Finalize
+
+After the last wave:
+- Stage the plan file's deletion (don't ship it).
+- Run the full verification: format + compile + unitTest + integrationTest, or `pnpm tsc --noEmit && pnpm test`, etc.
+- Push the branch.
+- Open the PR. Body must include:
+  - Link to the source ticket / issue.
+  - One-paragraph root-cause summary.
+  - Wave-by-wave summary: what each commit does, what was reviewed, what corrections happened.
+  - PR template checklist if the repo has one.
+
+## Red flags — STOP
+
+| Symptom | Meaning | Fix |
+|---------|---------|-----|
+| Trying to plan and dispatch in the same turn | Skipped the wave-splitting decision | Stop, write plan first |
+| Wave 1 dispatch already touches wave 2's surface | Boundaries wrong | Re-split or merge waves |
+| No verify step between waves | Errors cascade silently | Always verify before next dispatch |
+| Reviewer flags "scope change" | Wave boundary may be wrong | Cross-check plan; re-scope if needed |
+| Codex commits across the boundary you set | Boundary not enforced in prompt | Respawn with explicit "don't touch X" |
+| Considering a 5+-wave split | Over-decomposed | Combine until ≤ 3 unless each wave earns its review cycle |
+| Considering `codex exec` for review | Wrong tool — codex is for autonomous exec, review is read+reason | Use `superpowers:requesting-code-review` (default) or fresh `claude -p` (escalation) per "Review delegation" |
+| About to fan out review across many waves | Each wave's review is per-PR-single, not parallel — that's `codex-issue-waves` | Single-task waves run sequentially; reviews don't parallelize within one task |
+| Single-wave task, but you wrote 100 lines of plan | Plan is over-engineered for the task | Trim plan, dispatch, move on |
+| User said "just have codex fix it" but you start lecturing about waves | Single-wave answer was correct; just proceed | State "1 wave, here's why," then go |
+
+## When this skill applies
+
+- "Have codex fix this" / "have codex implement this" / "have codex handle this"
+- "Let codex do this" / "let codex take this ticket"
+- "Give this to codex" / "delegate this to codex"
+- Any single-task delegation where the user expects a PR they will review
+
+For multi-issue parallel waves see `codex-issue-waves`. For a one-shot codex dispatch with no plan and no wave structure see `invoking-codex-exec` directly.

--- a/invoking-codex-exec/SKILL.md
+++ b/invoking-codex-exec/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: invoking-codex-exec
+description: Use when delegating a single coding task to `codex exec` ("hand off to codex", "run codex on this", "dispatch codex on this ticket", any one-shot invocation). Covers flags, sandbox traps, monitoring, and recovery. Not for multi-issue parallel batches — use codex-issue-waves for those.
+---
+
+# Invoking codex exec
+
+Delegate a self-contained coding task to `codex exec` while you keep working in the main conversation. The codex subprocess edits files, runs builds, and reports back. You stay in command of the rest of the session.
+
+## Required flags
+
+```bash
+codex exec \
+  --dangerously-bypass-approvals-and-sandbox \
+  -C <worktree> \
+  --skip-git-repo-check \
+  "<prompt>"
+```
+
+- `--dangerously-bypass-approvals-and-sandbox`: required whenever codex needs to run gradle, maven, docker, npm scripts that bind sockets, or anything that touches privileged OS resources. The default `--full-auto` sandbox is `workspace-write`, which silently blocks daemon socket binding. Codex will spiral trying to bypass it instead of failing fast.
+- `-C <worktree>`: pin codex to the working tree. Required for worktree-isolated work.
+- `--skip-git-repo-check`: codex otherwise refuses to run in a worktree it considers ambiguous.
+
+**Don't use `--full-auto`** for any task that runs builds or tests. The flag name is misleading — the sandbox actively breaks gradle/maven/docker. Pure source-editing tasks are the only safe `--full-auto` use case, and even then the bypass flag is fine.
+
+## Sandbox-bypass spiral — KILL ON SIGHT
+
+If codex starts doing any of these, you launched with the wrong flag. Kill the run, restart with `--dangerously-bypass-approvals-and-sandbox`:
+
+- Writing into `/tmp/gradle-patch/`, `/tmp/gradle-home/`, `/tmp/maven-*`, `/tmp/docker-*`
+- Recompiling daemon/launcher classes: `BuildActionsFactory`, `DefaultFileLockCommunicator`, similar
+- `Expecting a stack map frame` JVM verifier errors
+- Patching jars with `jar uf` / `jar xf`
+- Re-pointing `GRADLE_USER_HOME`, `MAVEN_OPTS`, `DOCKER_HOST` to `/tmp` paths
+- Iterating on `--no-daemon` / `--offline` workarounds for >2 minutes
+- Recompiling toolchain-internal classes from decompiled bytecode
+
+The cost of letting it run is real: in one observed case, ~8 minutes wall clock and tens of thousands of tokens trying to recompile gradle's CLI to bypass its daemon. Restart is faster than waiting it out.
+
+For early detection, run `scripts/detect_sandbox_spiral.sh <logfile>` against the codex log. In follow mode it tails the log and emits one line per spiral signature — wire it through the Monitor tool so the harness surfaces a notification the moment the spiral starts (typically minute 1–2, well before the jar-patching phase). `--once <logfile>` does a one-shot scan and exits non-zero if any signature is present (use this in scripts or after-the-fact triage).
+
+## Monitoring — wait by PID, not by log
+
+Launch in background, redirect output, capture the PID:
+
+```bash
+codex exec --dangerously-bypass-approvals-and-sandbox -C <worktree> --skip-git-repo-check "..." > /tmp/codex-<id>.log 2>&1 &
+CODEX_PID=$!
+```
+
+Wait by process exit:
+
+```bash
+until ! kill -0 $CODEX_PID 2>/dev/null; do sleep 30; done
+```
+
+Or use the harness's background-task mechanism (Bash with `run_in_background`, ScheduleWakeup, or Monitor). For long runs (>5 min) prefer ScheduleWakeup with a 10–30 min delay over busy-polling.
+
+**Don't grep the log for "completion markers".** Codex emits bare-line section headers (`codex`, `exec`, `thinking`) interleaved with output. A regex like `^codex$` matches the section header and reports completion mid-run. The PID is authoritative; the log is for diagnosis only.
+
+## Before killing a stuck run — check the diff
+
+When you decide a codex run is wedged, do this in the worktree before killing:
+
+```bash
+git status --short
+git diff
+```
+
+Codex commits or stages edits as it works. The actual code change may already be correct even when codex is stuck in an unrelated dead-end (sandbox-bypass spiral, looping test rerun, retry storm on a network call). If the diff matches the plan, kill codex and finish the verification yourself — don't relaunch from scratch.
+
+This trust-but-verify check costs ~5 seconds and routinely saves a full re-run.
+
+## Prompt shape
+
+One prompt block, no nested instructions. Include:
+
+- Path to a plan file (if one exists) and an instruction to read it first.
+- Concrete verification commands to run from the worktree root (`./gradlew formatKotlin && ./gradlew compileKotlin && ./gradlew test`, `pnpm tsc --noEmit && pnpm test`, etc.).
+- Explicit boundaries: don't commit, don't push, don't edit CHANGELOG, don't bypass hooks.
+- Reference to project rules: `CLAUDE.md`, `AGENTS.md`.
+
+Brief codex like a smart engineer with zero session context. No "as we discussed" or "the file you saw earlier."
+
+## Red flags — STOP and fix the launch
+
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| Codex creates `/tmp/gradle-patch/` | Wrong sandbox flag | Kill, relaunch with `--dangerously-bypass-approvals-and-sandbox` |
+| Codex log says `Expecting a stack map frame` | Sandbox-bypass spiral | Same |
+| Wait loop exits but codex still running | Regex matched a section header | Wait by PID instead |
+| Killed codex, planning to relaunch | Probably forgot to check diff | `git status` first |
+| Used `--full-auto` for a build task | Default sandbox blocks daemons | Use bypass flag |
+| Codex prompt references "the plan we agreed on" | Missing context — codex has none | Inline the plan or pass a path |
+
+## When this skill applies
+
+- "Hand this off to codex" / "run codex on this"
+- "Dispatch codex on ticket X"
+- One-shot delegation of an implementation plan that already exists
+- Single-issue codex run, including inside a worktree
+
+For wave-structured single-task delegation (plan → split → review per wave) see `codex-task-waves`. For multi-issue parallel waves see `codex-issue-waves`. Both build on this skill.

--- a/invoking-codex-exec/scripts/detect_sandbox_spiral.sh
+++ b/invoking-codex-exec/scripts/detect_sandbox_spiral.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Detect codex-exec sandbox-bypass spirals from a codex log.
+#
+# Usage:
+#   detect_sandbox_spiral.sh <logfile>             # tail -f, emit one line per hit, run forever
+#   detect_sandbox_spiral.sh --once <logfile>      # scan existing content, exit 0 (clean) or 1 (spiral)
+#
+# Designed for use with the Monitor tool: each match becomes a stdout line, which
+# the harness surfaces as a notification. The agent decides whether to kill codex,
+# usually after a `git status` / `git diff` check (see SKILL.md "Before killing").
+#
+# Signatures are derived from a real spiral observed 2026-04-28: codex used
+# `--full-auto` (workspace-write sandbox), gradle daemon socket bind was blocked,
+# codex tried GRADLE_USER_HOME=/tmp, then patched the gradle CLI jar.
+
+set -euo pipefail
+
+mode="follow"
+if [[ "${1:-}" == "--once" ]]; then
+  mode="once"
+  shift
+fi
+
+logfile="${1:-}"
+if [[ -z "$logfile" ]]; then
+  echo "usage: $(basename "$0") [--once] <logfile>" >&2
+  exit 2
+fi
+if [[ ! -r "$logfile" ]]; then
+  echo "error: cannot read $logfile" >&2
+  exit 2
+fi
+
+# Earliest-to-latest signal order. Order does not matter for matching, but the
+# earlier signals (sandbox-policy rejections, GRADLE_USER_HOME=/tmp) tend to fire
+# minutes before the JVM-verifier and jar-patching ones.
+pattern='blocked by policy|rejected by policy|GRADLE_USER_HOME=/tmp|MAVEN_OPTS=.*-Duser\.home=/tmp|/tmp/gradle-(patch|home)|/tmp/maven-(patch|home)|Expecting a stack( |-)?map frame|BuildActionsFactory|DefaultFileLockCommunicator|PatchBuildActionsFactory|jar (uf|xf|cf) /tmp|--no-daemon.*--no-daemon|Net\.bind0|DatagramSocket.*bind'
+
+if [[ "$mode" == "once" ]]; then
+  hits=$(grep -nE "$pattern" "$logfile" 2>/dev/null || true)
+  if [[ -n "$hits" ]]; then
+    printf '%s\n' "$hits" | awk 'NR<=5'
+    exit 1
+  fi
+  exit 0
+fi
+
+# follow mode — line-buffered grep so events surface immediately
+exec tail -n0 -F "$logfile" 2>/dev/null \
+  | grep -E --line-buffered "$pattern" \
+  | awk '{ print "[sandbox-spiral] " $0; fflush(); }'


### PR DESCRIPTION
## What does this PR do?

Adds three codex delegation skills plus a top-level mermaid flowchart spanning them.

- **invoking-codex-exec** — primitive for one-shot `codex exec` dispatch. Required flags, sandbox-bypass spiral detection, PID-based monitoring, recovery via `git status`/`git diff` before kill.
- **codex-task-waves** — single-task delegation with a written plan, wave-splitting (1–3 typical), per-wave review via claude subagent or fresh `claude -p`, then PR.
- **codex-issue-waves** — multi-issue parallel batches. Pre-dispatch conflict triage, isolated worktrees, parallel codex runs, parallel claude reviewers, ordered merge + cleanup.
- **CODEX_WAVES.md** — single mermaid flowchart at repo root showing entry decision (`Task shape?`), per-skill subgraphs, and dotted layering edges where the wave skills call back into `invoking-codex-exec`. Includes picker table.

## Skill affected

- [x] New skill: invoking-codex-exec
- [x] New skill: codex-task-waves
- [x] New skill: codex-issue-waves
- [x] Other (README + new CODEX_WAVES.md)

## Checklist

- [x] No hardcoded credentials, tokens, or personal server details
- [x] Examples use placeholders
- [x] Commands tested against the actual service
- [x] SKILL.md frontmatter has correct \`name\` and \`description\`